### PR TITLE
Update indent rules for `loop`

### DIFF
--- a/indent/janet.vim
+++ b/indent/janet.vim
@@ -47,6 +47,8 @@ if exists("*searchpairpos")
 		let g:janet_align_subforms = 0
 	endif
 
+	let s:janet_loop_head_keywords = [ ':iterate', ':range', ':down', ':keys', ':in', ':generate', ':modifier', ':while', ':until', ':let', ':before', ':after', ':repeat', ':when' ]
+
 	function! s:syn_id_name()
 		return synIDattr(synID(line("."), col("."), 0), "name")
 	endfunction
@@ -158,6 +160,18 @@ if exists("*searchpairpos")
 		let i = s:check_for_string()
 		if i > -1
 			return [0, i + !!g:janet_align_multiline_strings]
+		endif
+
+		" Handle janet loop head keywords
+		if s:syn_id_name() =~? 'JanetLoopHead'
+			let lnum = prevnonblank(line('.') - 1)
+			let prev_line = getline(lnum)
+			let joined_keywords = join(s:janet_loop_head_keywords, '|')
+			let match_janet_loop_head_keyword = '\v' . joined_keywords
+			let m = match(prev_line, match_janet_loop_head_keyword)
+			if m > 0
+				return [0, m]
+			endif
 		endif
 
 		call cursor(0, 1)

--- a/indent/janet.vim
+++ b/indent/janet.vim
@@ -162,6 +162,18 @@ if exists("*searchpairpos")
 			return [0, i + !!g:janet_align_multiline_strings]
 		endif
 
+		" Handle janet loop head keywords
+		if s:syn_id_name() =~? 'JanetLoopHead'
+			let lnum = prevnonblank(line('.') - 1)
+			let prev_line = getline(lnum)
+			let joined_keywords = join(s:janet_loop_head_keywords, '|')
+			let match_janet_loop_head_keyword = '\v' . joined_keywords
+			let m = match(prev_line, match_janet_loop_head_keyword)
+			if m > 0
+				return [0, m]
+			endif
+		endif
+
 		call cursor(0, 1)
 
 		" Find the next enclosing [ or {. We can limit the second search
@@ -183,15 +195,15 @@ if exists("*searchpairpos")
 		" If the curly was not chosen, we take the bracket indent - if
 		" there was one.
 		if bracket[0] > paren[0] || bracket[1] > paren[1]
-			" Handle janet loop head keywords
-			if s:syn_id_name() =~? 'JanetLoopHead'
-				let lnum = prevnonblank(line('.') - 1)
-				let prev_line = getline(lnum)
+			let synIDs = map(synstack(bracket[0], bracket[1] + 1), 'synIDattr(v:val,"name")')
+			if index(synIDs, 'JanetLoopHead') >= 0
+				" We are in JanetLoopHead
+				let line = getline(bracket[0])
 				let joined_keywords = join(s:janet_loop_head_keywords, '|')
 				let match_janet_loop_head_keyword = '\v' . joined_keywords
-				let m = match(prev_line, match_janet_loop_head_keyword)
+				let m = match(line, match_janet_loop_head_keyword)
 				if m > 0
-					return [0, m]
+					return [bracket[0], m]
 				endif
 			endif
 			return bracket

--- a/indent/janet.vim
+++ b/indent/janet.vim
@@ -162,18 +162,6 @@ if exists("*searchpairpos")
 			return [0, i + !!g:janet_align_multiline_strings]
 		endif
 
-		" Handle janet loop head keywords
-		if s:syn_id_name() =~? 'JanetLoopHead'
-			let lnum = prevnonblank(line('.') - 1)
-			let prev_line = getline(lnum)
-			let joined_keywords = join(s:janet_loop_head_keywords, '|')
-			let match_janet_loop_head_keyword = '\v' . joined_keywords
-			let m = match(prev_line, match_janet_loop_head_keyword)
-			if m > 0
-				return [0, m]
-			endif
-		endif
-
 		call cursor(0, 1)
 
 		" Find the next enclosing [ or {. We can limit the second search
@@ -195,6 +183,17 @@ if exists("*searchpairpos")
 		" If the curly was not chosen, we take the bracket indent - if
 		" there was one.
 		if bracket[0] > paren[0] || bracket[1] > paren[1]
+			" Handle janet loop head keywords
+			if s:syn_id_name() =~? 'JanetLoopHead'
+				let lnum = prevnonblank(line('.') - 1)
+				let prev_line = getline(lnum)
+				let joined_keywords = join(s:janet_loop_head_keywords, '|')
+				let match_janet_loop_head_keyword = '\v' . joined_keywords
+				let m = match(prev_line, match_janet_loop_head_keyword)
+				if m > 0
+					return [0, m]
+				endif
+			endif
 			return bracket
 		endif
 

--- a/syntax/janet.vim
+++ b/syntax/janet.vim
@@ -24,9 +24,9 @@ syntax region JanetBuffer matchgroup=JanetStringDelimiter start=/@"/ skip=/\\\\\
 syntax region JanetString matchgroup=JanetStringDelimiter start="\z(`\+\)" end="\z1" contains=@Spell
 syntax region JanetBuffer matchgroup=JanetStringDelimiter start="@\z(`\+\)" end="\z1" contains=@Spell
 
-syn keyword JanetConstant nil 
+syn keyword JanetConstant nil
 
-syn keyword JanetBoolean true 
+syn keyword JanetBoolean true
 syn keyword JanetBoolean false
 
 " Janet special forms
@@ -446,7 +446,7 @@ call s:syntaxNumber('0x', '\&', '0123456789abcdef')
 unlet! s:radix_chars s:radix
 
 " -*- TOP CLUSTER -*-
-syntax cluster JanetTop contains=@Spell,JanetComment,JanetConstant,JanetQuote,JanetKeyword,JanetSymbol,JanetNumber,JanetString,JanetBuffer,JanetTuple,JanetArray,JanetTable,JanetStruct,JanetSpecialForm,JanetBoolean,JanetCoreValue
+syntax cluster JanetTop contains=@Spell,JanetComment,JanetConstant,JanetQuote,JanetKeyword,JanetSymbol,JanetNumber,JanetString,JanetBuffer,JanetTuple,JanetArray,JanetTable,JanetStruct,JanetSpecialForm,JanetBoolean,JanetCoreValue,JanetLoop
 
 syntax region JanetTuple matchgroup=JanetParen start="("  end=")" contains=@JanetTop fold
 syntax region JanetArray matchgroup=JanetParen start="@("  end=")" contains=@JanetTop fold
@@ -454,6 +454,10 @@ syntax region JanetTuple matchgroup=JanetParen start="\[" end="]" contains=@Jane
 syntax region JanetArray matchgroup=JanetParen start="@\[" end="]" contains=@JanetTop fold
 syntax region JanetTable matchgroup=JanetParen start="{"  end="}" contains=@JanetTop fold
 syntax region JanetStruct matchgroup=JanetParen start="@{"  end="}" contains=@JanetTop fold
+
+syntax region JanetLoopHead contained matchgroup=JanetParen start="\[" end="]" contains=JanetLoopKeyword,@JanetTop fold
+syntax keyword JanetLoopKeyword contained :iterate :range :down :keys :in :generate :modifier :while :until :let :before :after :repeat :when
+syntax keyword JanetLoop loop nextgroup=JanetLoopHead skipwhite
 
 " Highlight superfluous closing parens, brackets and braces.
 syntax match JanetError "]\|}\|)"
@@ -472,6 +476,9 @@ hi def link JanetString String
 hi def link JanetBuffer String
 hi def link JanetStringDelimiter String
 hi def link JanetBoolean Boolean
+hi def link JanetLoop Special
+hi def link JanetLoopKeyword Keyword
+hi def link JanetError Error
 
 hi def link JanetQuote SpecialChar
 hi def link JanetParen Delimiter


### PR DESCRIPTION
resolves #1 
* Add region detection for `loop`
* loop head will aligned to previous line's verb / modifiers keyword.