### PR TITLE
Set lisp option

### DIFF
--- a/ftplugin/janet.vim
+++ b/ftplugin/janet.vim
@@ -20,6 +20,9 @@ setlocal define=\\v[(/]def(ault)@!\\S*
 " Remove 't' from 'formatoptions' to avoid auto-wrapping code.
 setlocal formatoptions-=t
 
+" Enable lisp option (useful for plugins)
+setlocal lisp
+
 setlocal comments=n:#
 setlocal commentstring=#\ %s
 


### PR DESCRIPTION
Certain plugins (such as [vim-sexp](https://github.com/guns/vim-sexp)) identify Lisp files by checking whether the option `lisp` is set. This PR sets the option locally for Janet files.

This fixes #12.